### PR TITLE
Reduced the maximum f_blocks value to INT32_MAX

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -332,7 +332,7 @@ static int smb2fs_statfs(const char *path, struct statvfs *sfs)
 	blocks = smb2_sfs.f_blocks;
 	bfree  = smb2_sfs.f_bfree;
 	bavail = smb2_sfs.f_bavail;
-	while (blocks > UINT32_MAX)
+	while (blocks > INT32_MAX)
 	{
 		frsize <<= 1;
 		blocks >>= 1;


### PR DESCRIPTION
The id_NumBlocks, id_NumBlocksUsed and id_BytesPerBlock fields used to be signed LONGs in OS3, so overflows could still happen with UINT32_MAX.