### PR TITLE
Added an error requester for init and lowered the bsdsocket.library requirement

### DIFF
--- a/README-OS3
+++ b/README-OS3
@@ -10,6 +10,8 @@ Requirements:
 
 - filesysbox.library 54.3 or newer.
 
+- AmiTCP 3.0 or any compatible TCP/IP stack
+
 Usage:
 
 Create a DOSDriver with the contents:

--- a/makefile
+++ b/makefile
@@ -18,7 +18,7 @@ LIBS    =
 
 STRIPFLAGS = -R.comment --strip-unneeded-rel-relocs
 
-SRCS = start.c main.c reaction-password-req.c time.c bsdsocket-stubs.c
+SRCS = start.c main.c reaction-password-req.c error-req.c time.c bsdsocket-stubs.c
 
 OBJS = $(addprefix obj/,$(SRCS:.c=.o))
 DEPS = $(OBJS:.o=.d)

--- a/makefile.aros
+++ b/makefile.aros
@@ -16,7 +16,7 @@ CFLAGS  = $(OPTIMIZE) $(DEBUG) $(INCLUDES) $(DEFINES) $(WARNINGS)
 LDFLAGS = -nostartfiles
 LIBS    = -larosc -ldebug
 
-SRCS = start_os3.c main.c mui-password-req.c time.c strdup.c malloc.c
+SRCS = start_os3.c main.c mui-password-req.c error-req.c time.c strdup.c malloc.c
 
 OBJS = $(addprefix obj-aros/,$(SRCS:.c=.o))
 DEPS = $(OBJS:.o=.d)

--- a/makefile.os3
+++ b/makefile.os3
@@ -19,7 +19,7 @@ LIBS    = -ldebug
 
 #STRIPFLAGS = -R.comment --strip-unneeded-rel-relocs
 
-SRCS = start_os3.c main.c reaction-password-req.c time.c strlcpy.c strdup.c malloc.c
+SRCS = start_os3.c main.c reaction-password-req.c error-req.c time.c strlcpy.c strdup.c malloc.c
 
 ARCH_000 = -m68000
 OBJS_000 = $(addprefix obj-000/,$(SRCS:.c=.o))

--- a/src/error-req.c
+++ b/src/error-req.c
@@ -1,0 +1,77 @@
+/*
+ * smb2-handler - SMB2 file system client
+ *
+ * Copyright (C) 2022-2023 Fredrik Wikstrom <fredrik@a500.org>
+ * Copyright (C) 2023 Szilard Biro
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program (in the main directory of the smb2-handler
+ * distribution in the file COPYING); if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#define __USE_INLINE__
+
+#include "smb2fs.h"
+#include "smb2-handler_rev.h"
+
+#include <proto/exec.h>
+#include <proto/intuition.h>
+
+#ifndef __amigaos4__
+#include <clib/debug_protos.h>
+#endif
+
+#include <stdio.h>
+#include <string.h>
+
+void request_error(const char *error_string, ...)
+{
+#ifdef __amigaos4__
+	struct IntuitionIFace *IIntuition;
+#else
+	struct IntuitionBase *IntuitionBase;
+#endif
+	va_list args;
+	char errstr[256];
+
+	va_start(args, error_string);
+	vsnprintf(errstr, sizeof(errstr), error_string, args);
+	va_end(args);
+
+#ifdef __amigaos4__
+	DebugPrintF("[smb2fs] %s\n", errstr);
+	IIntuition = (struct IntuitionIFace *)open_interface("intuition.library", 53);
+	if (IIntuition != NULL)
+#else
+	KPrintF((STRPTR)"[smb2fs] %s\n", errstr);
+	IntuitionBase = (struct IntuitionBase *)OpenLibrary((STRPTR)"intuition.library", 39);
+	if (IntuitionBase != NULL)
+#endif
+	{
+		struct EasyStruct es;
+		es.es_StructSize = sizeof(es);
+		es.es_Flags = 0;
+		es.es_Title = (STRPTR)VERS;
+		es.es_TextFormat = (STRPTR)errstr;
+		es.es_GadgetFormat = (STRPTR)"OK";
+		EasyRequestArgs(NULL, &es, NULL, NULL);
+
+#ifdef __amigaos4__
+		close_interface((struct Interface *)IIntuition);
+#else
+		CloseLibrary((struct Library *)IntuitionBase);
+#endif
+	}
+}
+

--- a/src/smb2fs.h
+++ b/src/smb2fs.h
@@ -34,6 +34,7 @@ void close_interface(struct Interface *interface);
 #endif
 
 char *request_password(const char *user, const char *server);
+void request_error(const char *error_string, ...);
 
 int smb2fs_main(struct DosPacket *pkt);
 

--- a/src/start_os3.c
+++ b/src/start_os3.c
@@ -111,7 +111,7 @@ int startup(void)
 		goto cleanup;
 	}
 
-	SocketBase = OpenLibrary((STRPTR)bsdsocketName, 4);
+	SocketBase = OpenLibrary((STRPTR)bsdsocketName, 3);
 	if (SocketBase == NULL)
 	{
 		goto cleanup;


### PR DESCRIPTION
It was brought to my attention that the handler didn't start up with AmiTCP 3.0 beta 2, because it opened bsdsocket.library v4. I lowered this to 3, and now it's confirmed to be working.
The other change is that I added an EasyRequest-based error requester to smb2fs_init in addition to the debug prints. This way users can have some feedback if the share didn't mount without the use of Sashimi or serial debug. 