### PR TITLE
Added a ReqTools password requester for OS3

### DIFF
--- a/README-OS3
+++ b/README-OS3
@@ -6,7 +6,7 @@ Requirements:
 
 - AmigaOS 3.0 or newer.
 
-- Optional: requester.class (from ClassAct/ReAction) for the password requester.
+- Optional: ReqTools for the password requester.
 
 - filesysbox.library 54.3 or newer.
 

--- a/makefile.os3
+++ b/makefile.os3
@@ -19,7 +19,7 @@ LIBS    = -ldebug
 
 #STRIPFLAGS = -R.comment --strip-unneeded-rel-relocs
 
-SRCS = start_os3.c main.c reaction-password-req.c error-req.c time.c strlcpy.c strdup.c malloc.c
+SRCS = start_os3.c main.c rt-password-req.c error-req.c time.c strlcpy.c strdup.c malloc.c
 
 ARCH_000 = -mcpu=68000 -mtune=68000
 OBJS_000 = $(addprefix obj-000/,$(SRCS:.c=.o))

--- a/src/rt-password-req.c
+++ b/src/rt-password-req.c
@@ -1,0 +1,63 @@
+/*
+ * smb2-handler - SMB2 file system client
+ *
+ * Copyright (C) 2022-2023 Fredrik Wikstrom <fredrik@a500.org>
+ * Copyright (C) 2023 Szilard Biro
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program (in the main directory of the smb2-handler
+ * distribution in the file COPYING); if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "smb2fs.h"
+#include "smb2-handler_rev.h"
+
+#include <proto/exec.h>
+
+#include <libraries/reqtools.h>
+#include <proto/reqtools.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+char *request_password(const char *user, const char *server)
+{
+	struct Library *ReqToolsBase;
+	char *password = NULL;
+
+	ReqToolsBase = OpenLibrary((STRPTR)"reqtools.library", 38);
+	if (ReqToolsBase != NULL)
+	{
+		char bodytext[256];
+		char buffer[256];
+		LONG result;
+
+		snprintf(bodytext, sizeof(bodytext), "Enter password for %s@%s", user, server);
+
+		result = rtGetString((UBYTE *)buffer, sizeof(buffer)-1, (char *)VERS, NULL,
+			RTGS_GadFmt, "_Ok|_Cancel",
+			RTGS_TextFmt, bodytext,
+			RT_Underscore, '_',
+			TAG_END);
+
+		if (result && buffer[0] != '\0')
+		{
+			password = strdup(buffer);
+		}
+
+		CloseLibrary(ReqToolsBase);
+	}
+	return password;
+}


### PR DESCRIPTION
This PR should fix issue #12, as ReqTools.library doesn't load a prefs file form disk the first time it's opened. Since neither ReqTools nor requester.class can hide passwords with asterisks on OS3 there's no big downside of using this library instead.