### PR TITLE
Fixed connecting to shares without a password

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -153,6 +153,11 @@ static void *smb2fs_init(struct fuse_conn_info *fci)
 		}
 	}
 
+	if (password == NULL)
+	{
+		password = "";
+	}
+
 	smb2_set_security_mode(fsd->smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 	if (url->domain != NULL)
 	{


### PR DESCRIPTION
Even when a folder is shared without a password, you still need to send an empty string when connecting to it. Fixes #15.