### PR TITLE
Various fixes to compile with newer version of gcc

### DIFF
--- a/libsmb2-git/lib/init.c
+++ b/libsmb2-git/lib/init.c
@@ -194,7 +194,7 @@ smb2_parse_args(struct smb2_context *smb2, const char *args)
 struct smb2_url *smb2_parse_url(struct smb2_context *smb2, const char *url)
 {
         struct smb2_url *u;
-        char *ptr, *tmp, *pwd, str[MAX_URL_SIZE];
+        char *ptr, *tmp, *pwd, str[MAX_URL_SIZE + 1];
         char *args;
 
         if (strncmp(url, "smb://", 6)) {

--- a/src/main.c
+++ b/src/main.c
@@ -937,13 +937,13 @@ static void remove_double_quotes(char *argstr)
 	end   = start + strlen(start);
 
 	/* Strip leading white space characters */
-	while (isspace(start[0]))
+	while (isspace((int)start[0]))
 	{
 		start++;
 	}
 
 	/* Strip trailing white space characters */
-	while (end > start && isspace(end[-1]))
+	while (end > start && isspace((int)(end[-1])))
 	{
 		end--;
 	}

--- a/src/rt-password-req.c
+++ b/src/rt-password-req.c
@@ -32,12 +32,13 @@
 #include <stdio.h>
 #include <string.h>
 
+struct ReqToolsBase *ReqToolsBase = NULL;
+
 char *request_password(const char *user, const char *server)
 {
-	struct Library *ReqToolsBase;
 	char *password = NULL;
 
-	ReqToolsBase = OpenLibrary((STRPTR)"reqtools.library", 38);
+	ReqToolsBase = (struct ReqToolsBase *)OpenLibrary((STRPTR)"reqtools.library", 38);
 	if (ReqToolsBase != NULL)
 	{
 		char bodytext[256];
@@ -57,7 +58,8 @@ char *request_password(const char *user, const char *server)
 			password = strdup(buffer);
 		}
 
-		CloseLibrary(ReqToolsBase);
+		CloseLibrary((struct Library *)ReqToolsBase);
+		ReqToolsBase = NULL;
 	}
 	return password;
 }


### PR DESCRIPTION
A few minor changes I had to make in order to cross compile using Bebbo's gcc.

Made room for the null terminator in the string buffer for the URL.
Made some explicit casts that the compiler complained about.
Made ReqToolsBase a global variable to make the linker happy.